### PR TITLE
Add some benchmarks for SkyCoord

### DIFF
--- a/benchmarks/time_coordinates.py
+++ b/benchmarks/time_coordinates.py
@@ -1,6 +1,20 @@
+import numpy as np
 from astropy import coordinates
 from astropy import units
 
 
 def time_latitude():
     coordinates.Latitude(3.2, units.degree)
+
+
+class SkyCoordBenchmarks:
+    def setup(self):
+        N = int(1e6)
+        lon, lat = np.ones(N), np.ones(N)
+        self.coord = coordinates.SkyCoord(lon, lat, unit='deg', frame='icrs')
+
+    def time_repr(self):
+        repr(self.coord)
+
+    def time_icrs_to_galactic(self):
+        self.coord.transform_to('galactic')


### PR DESCRIPTION
@eteq This adds benchmarks for SkyCoord `repr` and `icrs` to `galactic` transformation, both of which I noticed are currently slow.

@mdboom I can't run the benchmarks on my machine, so this code is completely untested ... is it possible to run tests on pull request either on `travis-ci` or on `ci.scipy.org` or some other machine?
