### PR TITLE
Added command to run benchmarks with some old commits

### DIFF
--- a/cron.sh
+++ b/cron.sh
@@ -4,6 +4,7 @@ source ~/.zshrc
 git checkout master
 git pull
 asv run NEW
+asv run MISSING --steps=10
 git add -A
 git commit -m "New results"
 git push origin master


### PR DESCRIPTION
Just to start a discussion on this - I think it would be nice when we add new benchmarks to run them with some of the old commits. The current PR will actually make it run commits that have never been benchmarked before (which also adds points for existing benchmarks) but it might be nicer if we could run new benchmarks with already benchmarked committed, to 'complete' them. Is this what `EXISTING` will do? If so, maybe we could do both:

```
asv run EXISTING --steps=10
asv run MISSING --steps=10
```

@mdboom - what do you think is the right approach?
