### PR TITLE
Add basic cosmology timing tests

### DIFF
--- a/benchmarks/time_cosmology.py
+++ b/benchmarks/time_cosmology.py
@@ -1,0 +1,30 @@
+import numpy as np
+from astropy import units as u
+from astropy.cosmology import FlatLambdaCDM, LambdaCDM
+
+
+class LambdaCDMBenchmarks:
+    H0 = 65 * u.km / u.s / u.Mpc
+    TCMB0 = 2.7 * u.K
+    params = [
+        LambdaCDM(H0, 0.25, 0.65, TCMB0, 3.04),
+        LambdaCDM(H0, 0.6, 0.7, TCMB0, 4),
+        LambdaCDM(H0, 0.4, 0.2, TCMB0, 3.04),
+        FlatLambdaCDM(H0, 0.25, TCMB0, 3.04),
+        FlatLambdaCDM(H0, 0.25, TCMB0, 3.04,
+                      [0.05, 0.1, 0.15] * u.eV)
+    ]
+
+    def setup(self, cosmo):
+        self.cosmology = cosmo
+        self.test_zs = np.linspace(0.1, 5.0, 200)
+
+    def teardown(self, cosmo):
+        del self.cosmology
+        del self.test_zs
+
+    def time_lumdist(self, cosmo):
+        self.cosmology.luminosity_distance(self.test_zs)
+
+    def time_age(self, cosmo):
+        self.cosmology.age(self.test_zs)


### PR DESCRIPTION
Since we've had actual performance related issues raised for the cosmology
package, it seems like a good thing to have some benchmarks.

I haven't actually been able to run these -- something in the setup requires
anaconda, which I don't use.  But the class compiles and the methods run
without complaint, so it should be okay.