### PR TITLE
Run the benchmarks against 3.6 instead of 3.4

### DIFF
--- a/asv.conf.json
+++ b/asv.conf.json
@@ -1,6 +1,6 @@
 {
     // The versions of Python to test against
-    "pythons": ["2.7", "3.4"],
+    "pythons": ["2.7", "3.6"],
 
     "environment_type": "conda",
 


### PR DESCRIPTION
I propose to edit `asv.conf.json`  to run the benchmarks against Python 3.6 instead of 3.4.

Motivation:
* Python 3 users tend to be on the latest version;
* I find the benchmarks to be significantly faster on 3.6 compared to 3.4, cf the graph below which I tweeted here: https://twitter.com/GeertHub/status/817857735484198912

 ![optional caption text](https://pbs.twimg.com/media/C1mdA9NUUAA78OU.jpg) 