### PR TITLE
Fix io.ascii IPAC benchmarks

### DIFF
--- a/benchmarks/io_ascii/ipac.py
+++ b/benchmarks/io_ascii/ipac.py
@@ -1,17 +1,14 @@
 import os
 
 from astropy.io import ascii
-from astropy.io.ascii.ipac import IpacHeader, IpacHeaderSplitter, IpacData
+from astropy.io.ascii.ipac import Ipac
 
 HERE = os.path.abspath(os.path.dirname(__file__))
 
 
 class IPACSuite:
     def setup(self):
-        self.header = IpacHeader()
-        self.data = IpacData()
-        self.header.data = self.data
-        self.splitter = IpacHeaderSplitter()
+
         self.vals = [str(i + 1) for i in range(1000)]
         self.widths = [i + 1 for i in range(1000)]
         f = open(os.path.join(HERE, 'files', 'ipac', 'string.txt'))
@@ -19,6 +16,13 @@ class IPACSuite:
         f.close()
         self.table = ascii.read(os.path.join(HERE, 'files', 'ipac', 'string.txt'),
                                 format='ipac', guess=False)
+        self.reader = Ipac()
+        self.header = self.reader.header
+        self.data = self.reader.data
+        self.splitter = self.reader.data.splitter
+        self.header.cols = list(self.table.columns.values())
+        self.data.cols = list(self.table.columns.values())
+        self.data._set_fill_values(self.data.cols)
 
     def time_splitter(self):
         self.splitter.join(self.vals, self.widths)
@@ -27,12 +31,7 @@ class IPACSuite:
         self.header.get_cols(self.lines)
 
     def time_header_str_vals(self):
-        header = IpacHeader()
-        header.cols = list(self.table.columns.values())
-        header.DBMS = False
-        header.str_vals()
+        self.header.str_vals()
 
     def time_data_str_vals(self):
-        data = IpacData()
-        data.cols = list(self.table.columns.values())
-        data.str_vals()
+        self.data.str_vals()


### PR DESCRIPTION
I haven't identified just where the regression occurred, but @hamogu heavily refactored how io.ascii classes are set up and I suspect that might be what happened.  The point is that (at least for IPAC) you can't use the bare classes in isolation, they are really more integrated.

Anyway, I made it work.

Fixes #17 
