### PR TITLE
Removing numpy 1.11 from the default conf

### DIFF
--- a/asv.conf.json
+++ b/asv.conf.json
@@ -9,7 +9,7 @@
     // list indicates to just test against the default (latest)
     // version.
     "matrix": {
-        "numpy": ["1.11", "1.14"],
+        "numpy": ["1.14"],
         "Cython": [],
         "jinja2": [],
         "nomkl": [],


### PR DESCRIPTION
Astropy is not compatible with numpy 1.11 any more, so I'm removing it from the default config so people try to run the benchmarks as is don't run into errors.