### PR TITLE
add pytest dependency

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ addons:
 install:
   - git clone git://github.com/astropy/ci-helpers.git
   - source ci-helpers/travis/setup_conda.sh
-  - pip install asv
+  - pip install asv pytest
   - asv machine --machine Travis --os unknown --arch unknown --cpu unknown --ram unknown
 
 script:


### PR DESCRIPTION
This is a possible fix for the issue in #68 (see https://github.com/astropy/astropy-benchmarks/pull/68#issuecomment-431495075 and astropy/astropy#7932 for more context). If this passes it may be the best thing to do is merge this so that PRs get tested while we wait for astropy/astropy#7932, and then revert it later? (@pllim and @astrofrog may have opinions on this?)