### PR TITLE
Add fits benchmarks

### DIFF
--- a/benchmarks/io_fits.py
+++ b/benchmarks/io_fits.py
@@ -2,7 +2,7 @@ from io import BytesIO
 
 import numpy as np
 from astropy.table import Table
-from astropy.io.fits import BinTableHDU
+from astropy.io.fits import BinTableHDU, Header
 
 # Note that we use BytesIO here to avoid being sensitive to disk access times
 
@@ -49,3 +49,28 @@ class FITSBinTableHDU:
         x = np.repeat(b'a', 2_000_000)
         array = np.array(x, dtype=[('col', 'S1')])
         BinTableHDU.from_columns(array)
+
+
+class FITSHeader:
+    """
+    Tests of the Header interface
+    """
+
+    def setup(self):
+        cards = {'INT%d' % i: i for i in range(1000)}
+        cards.update({'FLT%d' % i: (i + i/10) for i in range(1000)})
+        cards.update({'STR%d' % i: 'VALUE %d' % i for i in range(1000)})
+        cards.update({'HIERARCH FOO BAR %d' % i: i for i in range(1000)})
+        self.hdr = Header(cards)
+
+    def time_get_int(self):
+        self.hdr.get('INT999')
+
+    def time_get_float(self):
+        self.hdr.get('FLT999')
+
+    def time_get_str(self):
+        self.hdr.get('STR999')
+
+    def time_get_hierarch(self):
+        self.hdr.get('HIERARCH FOO BAR 999')

--- a/benchmarks/io_fits.py
+++ b/benchmarks/io_fits.py
@@ -1,8 +1,9 @@
 from io import BytesIO
+from tempfile import mktemp
 
 import numpy as np
 from astropy.table import Table
-from astropy.io.fits import BinTableHDU, Header
+from astropy.io import fits
 
 # Note that we use BytesIO here to avoid being sensitive to disk access times
 
@@ -48,7 +49,15 @@ class FITSBinTableHDU:
     def time_from_columns_bytes(self):
         x = np.repeat(b'a', 2_000_000)
         array = np.array(x, dtype=[('col', 'S1')])
-        BinTableHDU.from_columns(array)
+        fits.BinTableHDU.from_columns(array)
+
+
+def make_header(ncards=1000):
+    cards = {'INT%d' % i: i for i in range(ncards)}
+    cards.update({'FLT%d' % i: (i + i/10) for i in range(ncards)})
+    cards.update({'STR%d' % i: 'VALUE %d' % i for i in range(ncards)})
+    cards.update({'HIERARCH FOO BAR %d' % i: i for i in range(ncards)})
+    return fits.Header(cards)
 
 
 class FITSHeader:
@@ -57,11 +66,8 @@ class FITSHeader:
     """
 
     def setup(self):
-        cards = {'INT%d' % i: i for i in range(1000)}
-        cards.update({'FLT%d' % i: (i + i/10) for i in range(1000)})
-        cards.update({'STR%d' % i: 'VALUE %d' % i for i in range(1000)})
-        cards.update({'HIERARCH FOO BAR %d' % i: i for i in range(1000)})
-        self.hdr = Header(cards)
+        self.hdr = make_header()
+        self.hdr_string = self.hdr.tostring()
 
     def time_get_int(self):
         self.hdr.get('INT999')
@@ -74,3 +80,32 @@ class FITSHeader:
 
     def time_get_hierarch(self):
         self.hdr.get('HIERARCH FOO BAR 999')
+
+    def time_tostring(self):
+        self.hdr.tostring()
+
+    def time_fromstring(self):
+        fits.Header.fromstring(self.hdr_string)
+
+
+class FITSHDUList:
+    """
+    Tests of the HDUList interface
+    """
+
+    def setup(self):
+        self.filename = mktemp(suffix='.fits')
+        hdr = make_header()
+        hdul = fits.HDUList([fits.PrimaryHDU(header=hdr)] +
+                            [fits.ImageHDU(header=hdr) for _ in range(100)])
+        hdul.writeto(self.filename)
+
+    def time_getheader(self):
+        fits.getheader(self.filename)
+
+    def time_getheader_ext50(self):
+        fits.getheader(self.filename, ext=50)
+
+    def time_len(self):
+        with fits.open(self.filename) as hdul:
+            len(hdul)


### PR DESCRIPTION
Closes #76, and also ref https://github.com/astropy/astropy/pull/8502



I ran this locally to compare https://github.com/astropy/astropy/pull/8502 with v3.0.2 (so the comparison also includes changes from https://github.com/astropy/astropy/pull/8428, it is just to check that it is working correclty):
```
(py37) ❯ asv compare 275807902 0608e7a57

All benchmarks:

       before           after         ratio
     [27580790]       [0608e7a5]
          728±1ms        741±0.3ms     1.02  io_fits.FITSBinTableHDU.time_from_columns_bytes
         33.2±1ms         21.1±0ms    ~0.63  io_fits.FITSHDUList.time_getheader
-         1.59±0s        157±0.1ms     0.10  io_fits.FITSHDUList.time_getheader_ext50
-         3.15±0s        256±0.6ms     0.08  io_fits.FITSHDUList.time_len
-      21.6±0.2ms      18.4±0.04ms     0.85  io_fits.FITSHeader.time_fromstring
      7.10±0.03μs      7.12±0.03μs     1.00  io_fits.FITSHeader.time_get_float
      7.70±0.05μs      7.68±0.04μs     1.00  io_fits.FITSHeader.time_get_hierarch
      7.06±0.02μs      7.13±0.04μs     1.01  io_fits.FITSHeader.time_get_int
      7.10±0.02μs      7.09±0.02μs     1.00  io_fits.FITSHeader.time_get_str
      2.46±0.06ms      2.36±0.01ms     0.96  io_fits.FITSHeader.time_tostring
           failed           failed      n/a  io_fits.FITSHighLevelTableBenchmarks.time_read_nommap
         200±20ms         191±10ms     0.96  io_fits.FITSHighLevelTableBenchmarks.time_write
```