### PR TITLE
Add raw import benchmark for astropy

### DIFF
--- a/benchmarks/imports.py
+++ b/benchmarks/imports.py
@@ -1,0 +1,5 @@
+# https://github.com/airspeed-velocity/asv/pull/832
+def timeraw_import_astropy():
+    return """
+    import astropy
+    """


### PR DESCRIPTION
Fix #20 

Using example from airspeed-velocity/asv#832

**NOTE from local testing without asv**

Subsequent import of `astropy` even after deleting it from Python namespace does not take as long as the initial import. 

```python
In [1]: %time import astropy                                                    
CPU times: user 455 ms, sys: 985 ms, total: 1.44 s
Wall time: 193 ms

In [2]: %time import astropy                                                    
CPU times: user 2 µs, sys: 2 µs, total: 4 µs
Wall time: 6.2 µs

In [3]: import sys                                                              

In [4]: del sys.modules['astropy']                                              

In [5]: %time import astropy                                                    
CPU times: user 1.78 ms, sys: 871 µs, total: 2.65 ms
Wall time: 2.77 ms
```

cc @mseifert04