### PR TITLE
Updated version of dependencies used in environment

### DIFF
--- a/asv.conf.json
+++ b/asv.conf.json
@@ -1,6 +1,6 @@
 {
     // The versions of Python to test against
-    "pythons": ["3.6"],
+    "pythons": ["3.7"],
 
     "environment_type": "conda",
 
@@ -9,12 +9,12 @@
     // list indicates to just test against the default (latest)
     // version.
     "matrix": {
-        "numpy": ["1.14"],
+        "numpy": ["1.17"],
         "Cython": [],
         "jinja2": [],
         "nomkl": [],
-        "scipy": ["1.0"],
-        "matplotlib": ["2.1"]
+        "scipy": ["1.3"],
+        "matplotlib": ["3.1"]
     },
 
     "dcvs": "git",


### PR DESCRIPTION
Alternative to https://github.com/astropy/astropy-benchmarks/pull/83 - basically we need to update the version of numpy to at least 1.16 since that's what astropy now requires. I updated to the most recent supported versions of several dependencies so that this lasts a little while.