### PR TITLE
Add pyyaml and remove helper import

### DIFF
--- a/asv.conf.json
+++ b/asv.conf.json
@@ -17,7 +17,8 @@
         "jinja2": [],
         "nomkl": [],
         "scipy": ["1.3"],
-        "matplotlib": ["3.1"]
+        "matplotlib": ["3.1"],
+        "pyyaml": []
     },
 
     "dcvs": "git",

--- a/benchmarks/imports.py
+++ b/benchmarks/imports.py
@@ -134,12 +134,6 @@ def timeraw_import_astropy_tests():
     """
 
 
-def timeraw_import_astropy_tests_helper():
-    return """
-    from astropy.tests import helper
-    """
-
-
 def timeraw_import_astropy_tests_runner():
     return """
     from astropy.tests import runner


### PR DESCRIPTION
* Add `pyyaml` to hopefully fix https://www.astropy.org/astropy-benchmarks/#imports.timeraw_import_astropy_io_misc_yaml
* Remove `timeraw_import_astropy_tests_helper` because it produces empty result, and probably overkill to begin with.