### PR TITLE
TST: Use Python 3.7 and asv dev

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ cache: ccache
 sudo: false
 
 python:
-  - 3.6
+  - 3.7
 
 addons:
   apt:
@@ -31,7 +31,7 @@ env:
 install:
   - git clone git://github.com/astropy/ci-helpers.git
   - source ci-helpers/travis/setup_conda.sh
-  - pip install asv
+  - pip install git+https://github.com/airspeed-velocity/asv.git
   - asv machine --machine Travis --os unknown --arch unknown --cpu unknown --ram unknown
 
 script:


### PR DESCRIPTION
Originally in #91 but really should be a standalone PR.

Since the nightly benchmark uses dev version of `asv`, why not also do it here? 