### PR TITLE
ENH: Add more table init benchmarks from taldcroft

### DIFF
--- a/benchmarks/table.py
+++ b/benchmarks/table.py
@@ -182,3 +182,70 @@ class TimeTableInitWithLists:
 
     def time_init_lists(self):
         Table([self.dat, self.dat, self.dat], names=['time', 'rate', 'error'])
+
+
+class TimeTableInitWithMultiDimLists:
+
+    def setup(self):
+        np_data_int = np.arange(1_000_000, dtype=np.int64)
+        np_data_str = np_data_int.astype('U')
+
+        self.data_int_1d = np_data_int.tolist()
+        self.data_int_2d = np_data_int.reshape(1000, 1000).tolist()
+        self.data_int_3d = np_data_int.reshape(1000, 100, 10).tolist()
+
+        self.data_int_masked_1d = self.data_int_1d.copy()
+        self.data_int_masked_2d = self.data_int_2d.copy()
+        self.data_int_masked_3d = self.data_int_3d.copy()
+
+        self.data_int_masked_1d[-1] = np.ma.masked
+        self.data_int_masked_2d[-1][-1] = np.ma.masked
+        self.data_int_masked_3d[-1][-1][-1] = np.ma.masked
+
+        self.data_str_1d = np_data_str.tolist()
+        self.data_str_2d = np_data_str.reshape(1000, 1000).tolist()
+        self.data_str_3d = np_data_str.reshape(1000, 100, 10).tolist()
+
+        self.data_str_masked_1d = self.data_str_1d.copy()
+        self.data_str_masked_2d = self.data_str_2d.copy()
+        self.data_str_masked_3d = self.data_str_3d.copy()
+
+        self.data_str_masked_1d[-1] = np.ma.masked
+        self.data_str_masked_2d[-1][-1] = np.ma.masked
+        self.data_str_masked_3d[-1][-1][-1] = np.ma.masked
+
+    def time_init_int_1d(self):
+        Table([self.data_int_1d])
+
+    def time_init_int_2d(self):
+        Table([self.data_int_2d])
+
+    def time_init_int_3d(self):
+        Table([self.data_int_3d])
+
+    def time_init_int_masked_1d(self):
+        Table([self.data_int_masked_1d])
+
+    def time_init_int_masked_2d(self):
+        Table([self.data_int_masked_2d])
+
+    def time_init_int_masked_3d(self):
+        Table([self.data_int_masked_3d])
+
+    def time_init_str_1d(self):
+        Table([self.data_str_1d])
+
+    def time_init_str_2d(self):
+        Table([self.data_str_2d])
+
+    def time_init_str_3d(self):
+        Table([self.data_str_3d])
+
+    def time_init_str_masked_1d(self):
+        Table([self.data_str_masked_1d])
+
+    def time_init_str_masked_2d(self):
+        Table([self.data_str_masked_2d])
+
+    def time_init_str_masked_3d(self):
+        Table([self.data_str_masked_3d])

--- a/benchmarks/table.py
+++ b/benchmarks/table.py
@@ -188,37 +188,28 @@ class TimeTableInitWithMultiDimLists:
 
     def setup(self):
         np_data_int = np.arange(1_000_000, dtype=np.int64)
+        np_data_float = np_data_int.astype(np.float64)
         np_data_str = np_data_int.astype('U')
 
         self.data_int_1d = np_data_int.tolist()
-        self.data_int_2d = np_data_int.reshape(1000, 1000).tolist()
+
         self.data_int_3d = np_data_int.reshape(1000, 100, 10).tolist()
 
         self.data_int_masked_1d = self.data_int_1d.copy()
-        self.data_int_masked_2d = self.data_int_2d.copy()
-        self.data_int_masked_3d = self.data_int_3d.copy()
-
         self.data_int_masked_1d[-1] = np.ma.masked
-        self.data_int_masked_2d[-1][-1] = np.ma.masked
+
+        self.data_int_masked_3d = self.data_int_3d.copy()
         self.data_int_masked_3d[-1][-1][-1] = np.ma.masked
 
+        self.data_float_1d = np_data_float.tolist()
+
         self.data_str_1d = np_data_str.tolist()
-        self.data_str_2d = np_data_str.reshape(1000, 1000).tolist()
-        self.data_str_3d = np_data_str.reshape(1000, 100, 10).tolist()
 
         self.data_str_masked_1d = self.data_str_1d.copy()
-        self.data_str_masked_2d = self.data_str_2d.copy()
-        self.data_str_masked_3d = self.data_str_3d.copy()
-
         self.data_str_masked_1d[-1] = np.ma.masked
-        self.data_str_masked_2d[-1][-1] = np.ma.masked
-        self.data_str_masked_3d[-1][-1][-1] = np.ma.masked
 
     def time_init_int_1d(self):
         Table([self.data_int_1d])
-
-    def time_init_int_2d(self):
-        Table([self.data_int_2d])
 
     def time_init_int_3d(self):
         Table([self.data_int_3d])
@@ -226,26 +217,14 @@ class TimeTableInitWithMultiDimLists:
     def time_init_int_masked_1d(self):
         Table([self.data_int_masked_1d])
 
-    def time_init_int_masked_2d(self):
-        Table([self.data_int_masked_2d])
-
     def time_init_int_masked_3d(self):
         Table([self.data_int_masked_3d])
+
+    def time_init_float_1d(self):
+        Table([self.data_float_1d])
 
     def time_init_str_1d(self):
         Table([self.data_str_1d])
 
-    def time_init_str_2d(self):
-        Table([self.data_str_2d])
-
-    def time_init_str_3d(self):
-        Table([self.data_str_3d])
-
     def time_init_str_masked_1d(self):
         Table([self.data_str_masked_1d])
-
-    def time_init_str_masked_2d(self):
-        Table([self.data_str_masked_2d])
-
-    def time_init_str_masked_3d(self):
-        Table([self.data_str_masked_3d])


### PR DESCRIPTION
Fix #99 

I only ported over the cells with `timeit` in https://gist.github.com/taldcroft/2fa546ecb13ebe4a7ebc33ffa5dbb016 . cc @mhvk 

The `setup` has a lot of copies of large arrays. If this will present memory problem, please let me know how to mitigate the problem. Thanks!

💯 

