### PR TITLE
MNT: Replace master with main

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -40,7 +40,7 @@ each benchmark once instead of taking an average of many runs. Nevertheless,
 this is the first step to make sure things are running correctly and can still
 give order of magnitude timings.
 
-To run asv properly on the latest commit in the upstream astropy master, you can
+To run asv properly on the latest commit in the upstream astropy main, you can
 do::
 
     $ asv run
@@ -170,6 +170,6 @@ benchmarks - we have machines that automatically do this every night.
 Notes to maintainers
 --------------------
 
-The ``master`` branch in this repository should not contain any results or built
+The ``main`` branch in this repository should not contain any results or built
 website. Results should be added to the ``results`` branch, and commits to the
 ``results`` branch trigger a build to the ``gh-pages`` branch.

--- a/cron.sh
+++ b/cron.sh
@@ -6,8 +6,8 @@ echo "asv: "`asv --version`
 echo "Machine: "$MACHINE
 
 git clean -fxd
-git checkout master
-git pull origin master
+git checkout main
+git pull origin main
 
 # We now run all benchmarks since the last one run in this benchmarks repository. This assumes
 # you have previously run at least ``asv run HEAD^!`` and added the results to the repository
@@ -28,7 +28,7 @@ timeout 7200 taskset -c 0 asv run ALL --skip-existing-commits || true
 git add results/$MACHINE
 git commit -m "New results from $MACHINE"
 
-git push origin master
+git push origin main
 asv gh-pages --no-push
 git push -f origin gh-pages
 


### PR DESCRIPTION
This PR attempts to replace all mention of `master` to `main` in this repository. This should be reviewed and merged right after the maintainer has renamed the default branch.

This is part of #103