### PR TITLE
Run benchmarks in quick mode in CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,7 +14,7 @@ jobs:
     - uses: actions/checkout@v4
     - uses: actions/setup-python@v5
       with:
-        python-version: 3.12
+        python-version: 3.11
     - name: Install asv
       run: python -m pip install asv
     - name: Configure asv

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,10 +11,5 @@ jobs:
     uses: OpenAstronomy/github-actions-workflows/.github/workflows/tox.yml@v1
     with:
       envs: |
-        - linux: py311-astropy50
-        - macos: py311-astropy51
-        - windows: py311-astropy52
-        - linux: py311-astropy53
-        - macos: py311-astropy60
         - windows: py311-astropy61
         - linux: py311-astropydev

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,5 +17,7 @@ jobs:
         python-version: 3.12
     - name: Install asv
       run: python -m pip install asv
+    - name: Configure asv
+      run: asv machine --machine GA --os unknown --arch unknown --cpu unknown --ram unknown
     - name: Run benchmarks in quick mode
       run: asv run --quick

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,16 +8,13 @@ on:
 
 jobs:
   test:
-    name: Run benchmarks
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v4
-    - uses: actions/setup-python@v5
-      with:
-        python-version: 3.11
-    - name: Install asv
-      run: python -m pip install asv
-    - name: Configure asv
-      run: asv machine --machine GA --os unknown --arch unknown --cpu unknown --ram unknown
-    - name: Run benchmarks in quick mode
-      run: asv run --quick
+    uses: OpenAstronomy/github-actions-workflows/.github/workflows/tox.yml@v1
+    with:
+      envs: |
+        - linux: py311-astropy50
+        - macos: py311-astropy51
+        - windows: py311-astropy52
+        - linux: py311-astropy53
+        - macos: py311-astropy60
+        - windows: py311-astropy61
+        - linux: py311-astropydev

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,5 +11,5 @@ jobs:
     uses: OpenAstronomy/github-actions-workflows/.github/workflows/tox.yml@v1
     with:
       envs: |
-        - windows: py311-astropystable
+        - linux: py311-astropystable
         - linux: py311-astropydev

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,1 +1,21 @@
 name: CI
+
+on:
+  pull_request:
+  push:
+    tags:
+      - '*'
+
+jobs:
+  test:
+    name: Run benchmarks
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - uses: actions/setup-python@v5
+      with:
+        python-version: 3.12
+    - name: Install asv
+      run: python -m pip install asv
+    - name: Run benchmarks in quick mode
+      run: asv run --quick

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,5 +11,5 @@ jobs:
     uses: OpenAstronomy/github-actions-workflows/.github/workflows/tox.yml@v1
     with:
       envs: |
-        - windows: py311-astropy61
+        - windows: py311-astropystable
         - linux: py311-astropydev

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,28 @@
+[tox]
+envlist =
+    py311-astropy{50,51,52,53,60,61,dev}
+isolated_build = True
+
+[testenv]
+skip_install = true
+setenv =
+    PIP_EXTRA_INDEX_URL = https://pypi.anaconda.org/liberfa/simple https://pypi.anaconda.org/astropy/simple
+changedir =
+    .tmp/{envname}
+deps =
+    asv
+    numpy
+    scipy
+    matplotlib
+    astropy50: astropy==5.0.*
+    astropy51: astropy==5.1.*
+    astropy52: astropy==5.2.*
+    astropy53: astropy==5.3.*
+    astropy60: astropy==6.0.*
+    astropy61: astropy==6.1.*
+    astropydev: astropy>=0.0.dev0
+    astropydev: pyerfa>=0.0.dev0
+
+commands =
+    asv machine --machine unknown --os unknown --arch unknown --cpu unknown --ram unknown --config {toxinidir}/asv.conf.json
+    asv run --quick --python=same --config {toxinidir}/asv.conf.json

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist =
-    py311-astropy{50,51,52,53,60,61,dev}
+    py311-astropy{61,dev}
 isolated_build = True
 
 [testenv]
@@ -14,11 +14,6 @@ deps =
     numpy
     scipy
     matplotlib
-    astropy50: astropy==5.0.*
-    astropy51: astropy==5.1.*
-    astropy52: astropy==5.2.*
-    astropy53: astropy==5.3.*
-    astropy60: astropy==6.0.*
     astropy61: astropy==6.1.*
     astropydev: astropy>=0.0.dev0
     astropydev: pyerfa>=0.0.dev0

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist =
-    py311-astropy{61,dev}
+    py311-astropy{stable,dev}
 isolated_build = True
 
 [testenv]
@@ -14,7 +14,7 @@ deps =
     numpy
     scipy
     matplotlib
-    astropy61: astropy==6.1.*
+    astropystable: astropy
     astropydev: astropy>=0.0.dev0
     astropydev: pyerfa>=0.0.dev0
 


### PR DESCRIPTION
We should make sure that there are no syntax or code issues and that the benchmarks run with the latest version of astropy, otherwise we risk introducing broken benchmarks here and breaking the astropy CI subsequently.