### PR TITLE
Add --show-stderr to asv run

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -20,4 +20,4 @@ deps =
 
 commands =
     asv machine --machine unknown --os unknown --arch unknown --cpu unknown --ram unknown --config {toxinidir}/asv.conf.json
-    asv run --quick --python=same --config {toxinidir}/asv.conf.json
+    asv run --quick --python=same --config {toxinidir}/asv.conf.json --show-stderr


### PR DESCRIPTION
Add --show-stderr to asv run to see if any error message pops up for the failing astropydev job (#131)