### PR TITLE
Benchmarks for timeseries `aggregate_downsample()`

### DIFF
--- a/benchmarks/timeseries.py
+++ b/benchmarks/timeseries.py
@@ -20,12 +20,14 @@ class TimeSeriesBenchmarks:
         ts["a"] = np.random.random(num_samples)  # plain Column
 
         ts["a_mc"] = MaskedColumn(ts["a"].value, mask=False)
-        ts["a_mc"][1] = True  # just to ensure some value is masked
+        ts["a_mc"].mask[1] = True  # just to ensure some value is masked
+        ts["a_mc"][2] = np.nan  # some nan values
 
         ts["a_q"] = ts["a"] * u.dimensionless_unscaled  # Quantity
 
         ts["a_mq"] = Masked(ts["a_q"])  # MaskedQuantity
-        ts["a_mq"][1] = True  # just to ensure some value is masked
+        ts["a_mq"].mask[1] = True  # just to ensure some value is masked
+        ts["a_mq"][2] = np.nan  # some nan values
 
         self.ts = ts
 

--- a/benchmarks/timeseries.py
+++ b/benchmarks/timeseries.py
@@ -6,6 +6,8 @@ from astropy.timeseries import TimeSeries, aggregate_downsample
 import astropy.units as u
 from astropy.utils.masked import Masked
 
+from asv_runner.benchmarks.mark import skip_for_params
+
 
 class TimeSeriesBenchmarks:
     params = [
@@ -51,15 +53,16 @@ class TimeSeriesBenchmarks:
 
         self.ts = ts
 
+    # FIXME: for case MaskedQuantity with np.add,
+    # it hits the known issue in astropy/utils/masked/core.py
+    #   NotImplementedError: masked instances cannot yet deal with 'reduceat' or 'at'.
+    # tracked at the meta-issue  https://github.com/astropy/astropy/issues/11539
+    @skip_for_params(
+        [
+            ("mqty", np.add),
+        ]
+    )
     def time_aggregate_downsample(self, col_type, aggregate_func):
-        if col_type == "mqty" and aggregate_func is np.add:
-            # FIXME: it hits the known issue in astropy/utils/masked/core.py
-            #   NotImplementedError: masked instances cannot yet deal with 'reduceat' or 'at'.
-            # tracked at the meta-issue  https://github.com/astropy/astropy/issues/11539
-            #
-            # Ideally we should tell asv to skip this combination,
-            # use a simple return as a workaround.
-            return
         aggregate_downsample(
             self.ts, time_bin_size=5 * u.d, aggregate_func=aggregate_func
         )

--- a/benchmarks/timeseries.py
+++ b/benchmarks/timeseries.py
@@ -1,0 +1,50 @@
+import numpy as np
+
+from astropy.table import MaskedColumn
+from astropy.time import Time
+from astropy.timeseries import TimeSeries, aggregate_downsample
+import astropy.units as u
+from astropy.utils.masked import Masked
+
+
+class TimeSeriesBenchmarks:
+    def setup(self):
+        num_samples = 1000
+        time_diff = np.linspace(1, num_samples, num=num_samples)
+
+        ts = TimeSeries(time=Time(2450000 + time_diff, format="jd"))
+
+        # Columns with various column types
+        np.random.seed(12345)
+
+        ts["a"] = np.random.random(num_samples)  # plain Column
+
+        ts["a_mc"] = MaskedColumn(ts["a"].value, mask=False)
+        ts["a_mc"][1] = True  # just to ensure some value is masked
+
+        ts["a_q"] = ts["a"] * u.dimensionless_unscaled  # Quantity
+
+        ts["a_mq"] = Masked(ts["a_q"])  # MaskedQuantity
+        ts["a_mq"][1] = True  # just to ensure some value is masked
+
+        self.ts = ts
+
+    def _do_time_aggregate_downsample(self, aggregate_func):
+        aggregate_downsample(
+            self.ts, time_bin_size=5 * u.d, aggregate_func=aggregate_func
+        )
+
+    def time_aggregate_downsample_default(self):
+        # case default aggregate_func (optimized in v7.1.0+)
+        self._do_time_aggregate_downsample(None)
+
+    def time_aggregate_downsample_np_nanmean(self):
+        # case non-optimized aggregate_func
+        self._do_time_aggregate_downsample(np.nanmean)
+
+    # FIXME: it hits the known issue in astropy/utils/masked/core.py
+    #   NotImplementedError: masked instances cannot yet deal with 'reduceat' or 'at'.
+    #   relevant PR: https://github.com/astropy/astropy/pull/17875
+    # def time_aggregate_downsample_np_add(self):
+    #     # case aggregate_func is optimized (with `.reduceat`)
+    #     self._do_time_aggregate_downsample(np.add)


### PR DESCRIPTION
Would have caught the performance regression in v7.1.0 ( https://github.com/astropy/astropy/issues/18176 ), being fixed by PR https://github.com/astropy/astropy/pull/18188 .

The benchmark results on my machine

| `aggregate_func` | v7.1.0     | with astropy PR #18188 |
| ---------------- | ---------- | ---------------------- |
| `None`           | 9.49±0.2ms | 9.79±0.3ms             |
| `np.nanmean`     | 186±20ms   | 119±3ms                |


@mvhk @pllim 

